### PR TITLE
Исправление ошибки 429

### DIFF
--- a/custom_components/haier_evo/api.py
+++ b/custom_components/haier_evo/api.py
@@ -21,7 +21,7 @@ from enum import Enum
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from ratelimit import limits, sleep_and_retry
 
-CALLS = 150
+CALLS = 5
 RATE_LIMIT = 60  # секунды
 
 SST_CLOUD_API_URL = "https://api.sst-cloud.com/"
@@ -58,6 +58,9 @@ class Haier:
         try:
             # Setting a default timeout for requests
             kwargs.setdefault('timeout', 15)  # 10 seconds timeout
+            headers = kwargs.setdefault("headers", {})
+            headers.setdefault("User-Agent", "curl/7.81.0")
+            headers.setdefault("Accept", "*/*")
             resp = requests.request(method, url, **kwargs)
 
             # Handling 429 Too Many Requests with retry


### PR DESCRIPTION
Сервер блокирует запрос на логин без заголовков и в течении приблизительно часа отдает на этот адрес ошибку 429. При этом, если адрес не заблокирован, то через curl запросы идут, при умеренной частоте запросов. Изменения добавляют заголовки в запрос, чтобы после первого запроса сервер не блокировал адрес.

Работа проверена на кондиционере HSU12HPL203: работает без нареканий!

Fix #29