### PR TITLE
Добавлена поддержка внутреннего блока AS20HQJ1HRA

### DIFF
--- a/custom_components/haier_evo/devices/AS20HQJ1HRA.yaml
+++ b/custom_components/haier_evo/devices/AS20HQJ1HRA.yaml
@@ -1,0 +1,46 @@
+command_name: "3"
+attributes:
+  - name: current_temperature
+    id: "0"
+  - name: target_temperature
+    id: "31"
+  - name: status
+    id: "21"
+  - name: swing_mode
+    id: "8"
+    mappings:
+      - haier: 0
+        value: "off"
+      - haier: 8
+        value: "auto"
+  - name: mode
+    id: "5"
+    mappings:
+      - haier: "0"
+        value: "auto"
+      - haier: "1"
+        value: "cool"
+      - haier: "2"
+        value: "dry"
+      - haier: "4"
+        value: "heat"
+      - haier: "6"
+        value: "fan_only"
+  - name: fan_mode
+    id: "6"
+    mappings:
+      - haier: "1"
+        value: "high"
+      - haier: "2"
+        value: "medium"
+      - haier: "3"
+        value: "low"
+      - haier: "5"
+        value: "auto"
+  - name: light
+    id: "23"
+    mappings:
+      - haier: "1"
+        value: "off"
+      - haier: "0"
+        value: "on"


### PR DESCRIPTION
Добавлена поддержка внутреннего блока AS20HQJ1HRA (**HAIER QUANTUM DC AS20HQJ1HRA-W** или **HAIER QUANTUM DC AS20HQJ1HRA-B**). Доступен следующий функционал:

- Установка/чтение температуры
- Статус
- Управление шторокой
  - Авто
  - Фиксированно
- Режим работы
  - Авто
  - Охлаждение
  - Осушение
  - Нагрев
  - Вентиляция
- Скорость вентилятора
  - Авто
  - Низкая
  - Средняя
  - Высокая
- Подсветка табло
  - Вкл
  - Выкл

P.S. Что интересно, что управление подсветкой недоступно в штатном приложении, так что управление через HA дает даже больше возможностей :)