### PR TITLE
ConfigFlow падало на новых версиях HA + дебаг-логгинг интеграции

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+Home Assistant custom integration (HACS) for the Haier Evo cloud (RU/KZ/BY). Single package: `custom_components/haier_evo/`. README, translations, and most commit messages are in Russian.
+
+## Verification
+
+- No test suite, linter, or type checker. CI (`.github/workflows/validate.yaml`) only runs HACS repo validation on push/PR.
+- Quick syntax check: `python3 -m compileall -q custom_components/haier_evo`
+- Real verification requires a running HA instance with a Haier account; debugging dumps: `GET /api/haier_evo` on the HA instance returns full integration state (POST to it is disabled by default).
+
+## Architecture (non-obvious)
+
+- Cloud polling + websocket push. REST (auth, device list) at `evo.haieronline.ru`; live status via persistent WSS using the sync `websocket-client` lib in a daemon thread — **not asyncio**. State reaches the event loop via `hass.loop.call_soon_threadsafe`; blocking calls go through `async_add_executor_job` (`__init__.py`). Don't naively convert to async.
+- The `Haier` object lives in `hass.data[DOMAIN][entry_id]`. Device classes `HaierAC`/`HaierREF`/`HaierWM` (in `api.py`) are chosen from the `type` query param of the device link (`AC`/`REF`/`WM`); unknown types stay base `HaierDevice` and create no entities.
+- Entities are created dynamically per device: platform files (`climate.py`, `switch.py`, ...) are thin; the `create_entities_*` methods on the device class decide what exists based on configured attributes.
+- All commands go through `Constraint.apply` (`config.py`), which prepends/appends additional commands required by the device (from API `constraint` data).
+
+## Device model YAMLs
+
+- `devices/<MODEL>.yaml` maps numeric attribute codes (`id`) to canonical names and `haier` codes to canonical values; fallback is `devices/default.yaml` (ids blank).
+- **Gotcha:** on first setup the YAML is copied to `<HA config>/haier_evo.<MODEL>.yaml`, and that user copy then takes precedence forever. Repo-side YAML edits have no effect on installs that already have the copy — delete the user copy to test changes (`config.py:_find_config_file`).
+- The API returns Russian attribute/value names. Mapping to canonical names is hardcoded in `config.py`: `Attribute.__init__` (attr names) and the `Item` subclasses (`Mode`, `FanMode`, `SwingMode`, `Temperature`, ...). New attributes/values need entries there, not just YAML.
+
+## Auth and rate limits (don't hammer)
+
+- Tokens are persisted as plain JSON in `<HA config>/haier_evo` file.
+- All calls run through `ResettableLimits` (`limits.py`, subclass of `ratelimit`'s decorator): login/refresh 1 per 15s with backoff growing to 900s; general API 5 per 60s. 429/500 responses extend the backoff. Failed login attempts lock out progressively up to 15 minutes — bad for testing.
+
+## Releases
+
+- Bump `version` in `custom_components/haier_evo/manifest.json`; HACS uses it for update detection. Repo has no git tags/releases — HACS tracks the default branch.
+- `hacs.json` pins minimum HA version (currently 2024.12.0); code may use modern Python (3.10+ unions, enum flags like `ClimateEntityFeature`).

--- a/custom_components/haier_evo/api.py
+++ b/custom_components/haier_evo/api.py
@@ -6,6 +6,8 @@ import threading
 import uuid
 import socket
 import weakref
+import logging
+import re
 from aiohttp import web
 from enum import Enum
 from datetime import datetime, timezone, timedelta
@@ -23,6 +25,15 @@ from .logger import _LOGGER
 from .limits import ResettableLimits
 from . import config as CFG # noqa
 from . import const as C # noqa
+
+_TOKEN_RE = re.compile(r'("(?:accessToken|refreshToken|token)"\s*:\s*")([^"]+)(")')
+
+
+def _redact(text) -> str:
+    """Mask token values so they don't leak into debug logs."""
+    if not isinstance(text, str):
+        text = str(text)
+    return _TOKEN_RE.sub(r'\1<redacted>\3', text)
 
 
 class InvalidAuth(HomeAssistantError):
@@ -274,7 +285,9 @@ class Haier(object):
             headers.setdefault('Platform', "android")
             headers.setdefault('Accept', "*/*")
             resp = requests.request(method, url, **kwargs)
-            # _LOGGER.debug(resp.text)
+            _LOGGER.debug(f"{method} {url} -> {resp.status_code}")
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(f"Response body: {_redact(resp.text)}")
             # Handling 429 Too Many Requests with retry
             if resp.status_code == 429:
                 raise ManyRequestsError("429 Too Many Requests", response=resp)
@@ -407,7 +420,9 @@ class Haier(object):
                 'Device-Id': self._device_id,
                 'Content-Type': 'application/json'
             }, timeout=C.API_TIMEOUT)
-            # _LOGGER.debug(response.text)
+            _LOGGER.debug(f"Getting devices -> {response.status_code}")
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(f"Response body: {_redact(response.text)}")
             response.raise_for_status()
             data = response.json().get("data", {})
             assert isinstance(data, dict), f"Data is not dict: {data}"
@@ -433,8 +448,9 @@ class Haier(object):
                 'Device-Id': self._device_id,
                 'Content-Type': 'application/json'
             }, timeout=C.API_TIMEOUT)
-            # _LOGGER.debug(f"Update device {device_mac} status code: {response.status_code}")
-            # _LOGGER.debug(response.text)s
+            _LOGGER.debug(f"Getting status of device {device_mac} -> {response.status_code}")
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(f"Response body: {_redact(response.text)}")
             response.raise_for_status()
             data = response.json()
             return data

--- a/custom_components/haier_evo/config_flow.py
+++ b/custom_components/haier_evo/config_flow.py
@@ -60,7 +60,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
+        self._entry = config_entry
 
     async def async_step_init(self, user_input=None):
         errors = {}
@@ -68,9 +68,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             try:
                 info = await validate_input(self.hass, user_input)
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry,
+                    self._entry,
                     title=info["title"],
-                    data={**self.config_entry.data, **user_input},
+                    data={**self._entry.data, **user_input},
                 )
                 return self.async_create_entry(title="", data={})
             except InvalidEmail:
@@ -82,7 +82,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
-        current = self.config_entry.data
+        current = self._entry.data
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema({

--- a/custom_components/haier_evo/logger.py
+++ b/custom_components/haier_evo/logger.py
@@ -3,5 +3,9 @@ import logging
 
 
 logging.getLogger("websocket").setLevel(logging.CRITICAL)
+# Do not force a level here: it would override the `logger:` setting
+# in the user's configuration.yaml. Control verbosity from HA config:
+# logger:
+#   logs:
+#     custom_components.haier_evo: debug
 _LOGGER = logging.getLogger("custom_components.haier_evo")
-_LOGGER.setLevel(logging.INFO)


### PR DESCRIPTION
Disclaimer: навайбкожено, но программирую давно, чтоб валидировать код.

1. Добавлен файл AGENTS.md, т.к. использую GLM для кодинга.
2. На версии 2026.09.1 при нажатии на шестеренку с настройками падало с 500-кой.
3. Отлаживал подключение кондиционера с учеткой Evo и нужны были дополнительные логи.

PS: Пароль на сайте haieronline.ru и в API evo.haieronline.ru не синхронизируются. Если пройти путь восстановления пароля в мобильном приложении, то пароль потом принимается.